### PR TITLE
Fix getting matched count

### DIFF
--- a/tipgstac/dependencies.py
+++ b/tipgstac/dependencies.py
@@ -161,6 +161,8 @@ async def CollectionsParams(  # noqa: C901
     matched = None
     if context := results.get("context"):
         matched = context.get("matched")
+    else:
+        matched = results.get("numberMatched")
 
     for collection in results.get("collections", []):
         collections.append(


### PR DESCRIPTION
Fix errors "unsupported operand type(s) for -: 'NoneType' and 'int'" at /collections

## Available PR templates

<!--
  Github doesn't allow PR template selection the same way that it is possible with issues.
  Preview this and select the appropriate template
-->

- [Default](?expand=1&template=default.md)
- [Version Release](?expand=1&template=version_release.md)
- _Alternatively delete and start empty_
